### PR TITLE
chore: Release 2025.06

### DIFF
--- a/applications/aks/gitops/values/backend-services/app-repository.yaml
+++ b/applications/aks/gitops/values/backend-services/app-repository.yaml
@@ -33,7 +33,7 @@ serviceAccount:
     clientId: 
     enabled: true
 image:
-  tag: "2025.04"
+  tag: "2025.06"
   repository: uniquehelloazure.azurecr.io/backend-service-app-repository
 env: {}
 envVars:

--- a/applications/aks/gitops/values/backend-services/assistants-core.yaml
+++ b/applications/aks/gitops/values/backend-services/assistants-core.yaml
@@ -9,7 +9,7 @@ env:
 eventBasedAutoscaling:
   enabled: false
 image:
-  tag: "2025.04"
+  tag: "2025.06"
   repository: uniquehelloazure.azurecr.io/ai-service-assistants-core
 nodeSelector:
   scalability: steady

--- a/applications/aks/gitops/values/backend-services/chat.yaml
+++ b/applications/aks/gitops/values/backend-services/chat.yaml
@@ -45,7 +45,8 @@ env:
     {"name": "AgenticSearch", "apiURL": "http://assistants-core.unique.svc.cluster.local:8081/core/agentic_search"},
     {"name": "TranslatorV2", "apiURL": "http://assistants-core.unique.svc.cluster.local:8081/core/translator_v2"},
     {"name": "InvestmentResearch", "apiURL": "http://assistants-core.unique.svc.cluster.local:8081/core/investment_research"},
-    {"name": "EarningCallsBeta", "apiURL": "http://assistants-core.unique.svc.cluster.local:8081/core/earning_calls"}
+    {"name": "EarningCallsBeta", "apiURL": "http://assistants-core.unique.svc.cluster.local:8081/core/earning_calls"},
+    {"name": "HallucinationLevelEvaluation", "apiURL": "http://assistants-core.unique.svc.cluster.local:8081/core/evaluations/hallucination-level"}
     ]
   LOG_LEVEL: info
   MAX_HEAP_MB: 3700
@@ -81,7 +82,7 @@ hooks:
       cd /node/dist/apps/node-chat; npx prisma migrate deploy; cd /node; RUNNING_MODE=DATA_MIGRATION  node /node/dist/apps/node-chat/main.js up;
     enabled: true
 image:
-  tag: "2025.04"
+  tag: "2025.06"
   repository: uniquehelloazure.azurecr.io/backend-service-chat
 nodeSelector:
   scalability: steady

--- a/applications/aks/gitops/values/backend-services/client-insights-exporter.yaml
+++ b/applications/aks/gitops/values/backend-services/client-insights-exporter.yaml
@@ -20,7 +20,7 @@ env:
   LOG_LEVEL: info
   MAX_HEAP_MB: 200
 image:
-  tag: "2025.04"
+  tag: "2025.06"
   repository: uniquehelloazure.azurecr.io/backend-service-client-insights-exporter
 nodeSelector:
   scalability: steady

--- a/applications/aks/gitops/values/backend-services/event-socket.yaml
+++ b/applications/aks/gitops/values/backend-services/event-socket.yaml
@@ -23,7 +23,7 @@ envVars:
         name: rabbitmqcluster-chat-default-user
         key: port
 image:
-  tag: "2025.04"
+  tag: "2025.06"
   repository: uniquehelloazure.azurecr.io/backend-service-event-socket
 nodeSelector:
   scalability: steady

--- a/applications/aks/gitops/values/backend-services/ingestion-worker.yaml
+++ b/applications/aks/gitops/values/backend-services/ingestion-worker.yaml
@@ -39,7 +39,7 @@ envVars:
         name: rabbitmqcluster-chat-default-user
         key: port
 image:
-  tag: "2025.04"
+  tag: "2025.06"
   repository: uniquehelloazure.azurecr.io/backend-service-ingestion-worker
 eventBasedAutoscaling:
   enabled: false #! fixme: can only be enabled if the helm chart is fixed

--- a/applications/aks/gitops/values/backend-services/ingestion.yaml
+++ b/applications/aks/gitops/values/backend-services/ingestion.yaml
@@ -21,7 +21,7 @@ cronJob:
   suspend: false
   timeZone: Europe/Zurich
 image:
-  tag: "2025.04"
+  tag: "2025.06"
   repository: uniquehelloazure.azurecr.io/backend-service-ingestion
 env:
   ADDITIONAL_INGESTION_QUEUES: '["chat_queue"]'

--- a/applications/aks/gitops/values/backend-services/scope-management.yaml
+++ b/applications/aks/gitops/values/backend-services/scope-management.yaml
@@ -15,7 +15,7 @@ cronJob:
   suspend: false
   timeZone: Europe/Zurich
 image:
-  tag: "2025.04"
+  tag: "2025.06"
   repository: uniquehelloazure.azurecr.io/backend-service-scope-management
 env:
   AUDIT_LOG_DIR: /dev/stdout

--- a/applications/aks/gitops/values/backend-services/theme.yaml
+++ b/applications/aks/gitops/values/backend-services/theme.yaml
@@ -3,7 +3,7 @@ env:
   LOG_LEVEL: info
   MAX_HEAP_MB: 200
 image:
-  tag: "2025.04"
+  tag: "2025.06"
   repository: uniquehelloazure.azurecr.io/backend-service-theme
 hooks:
   migration:

--- a/applications/aks/gitops/values/backend-services/webhook-scheduler.yaml
+++ b/applications/aks/gitops/values/backend-services/webhook-scheduler.yaml
@@ -24,7 +24,7 @@ envVars:
         name: rabbitmqcluster-chat-default-user
         key: port
 image:
-  tag: "2025.04"
+  tag: "2025.06"
   repository: uniquehelloazure.azurecr.io/backend-service-webhook-scheduler
 nodeSelector:
   scalability: steady

--- a/applications/aks/gitops/values/backend-services/webhook-worker.yaml
+++ b/applications/aks/gitops/values/backend-services/webhook-worker.yaml
@@ -24,7 +24,7 @@ envVars:
         name: rabbitmqcluster-chat-default-user
         key: port
 image:
-  tag: "2025.04"
+  tag: "2025.06"
   repository: uniquehelloazure.azurecr.io/backend-service-webhook-worker
 nodeSelector:
   scalability: steady

--- a/applications/aks/gitops/values/web-apps/admin.yaml
+++ b/applications/aks/gitops/values/web-apps/admin.yaml
@@ -1,11 +1,9 @@
 env:
-  FEATURE_FLAG_ENABLE_ASSISTANT_ACCESS_UN_5775: true
-  FEATURE_FLAG_KNOWLEDGE_SCOPE_UN_5773: true
   FEATURE_FLAG_ENABLE_NOTIFICATION_BANNER_UN_9411: true
   MAX_HEAP_MB: 350
   SELF_URL: https://hello.azure.unique.dev/admin
 image:
-  tag: "2025.04"
+  tag: "2025.06"
   repository: uniquehelloazure.azurecr.io/web-app-admin
 nodeSelector:
   scalability: steady

--- a/applications/aks/gitops/values/web-apps/chat.yaml
+++ b/applications/aks/gitops/values/web-apps/chat.yaml
@@ -4,7 +4,6 @@ env:
   FEATURE_FLAG_IN_DOCUMENT_TRANSLATOR_UN_8405: "true"
   FEATURE_FLAG_NET_PROMOTER_SCORE_UI_UN_7747: "true"
   FEATURE_FLAG_NEW_TRANSLATION_UI_UN_7233: "true"
-  FEATURE_FLAG_STOP_STREAMING_UN_4824: "true"
   FILE_TYPES_DOCUMENT_TRANSLATOR: "docx,xlsx"
   MAX_FILE_SIZE_IN_MB: 200
   MAX_HEAP_MB: 400
@@ -36,7 +35,7 @@ extraRoutes:
           type: Exact
           value: /
 image:
-  tag: "2025.04"
+  tag: "2025.06"
   repository: uniquehelloazure.azurecr.io/web-app-chat
 nodeSelector:
   scalability: steady

--- a/applications/aks/gitops/values/web-apps/knowledge-upload.yaml
+++ b/applications/aks/gitops/values/web-apps/knowledge-upload.yaml
@@ -3,7 +3,7 @@ env:
   MAX_HEAP_MB: 350
   SELF_URL: https://hello.azure.unique.dev/knowledge-upload
 image:
-  tag: "2025.04"
+  tag: "2025.06"
   repository: uniquehelloazure.azurecr.io/web-app-knowledge-upload
 nodeSelector:
   scalability: steady

--- a/applications/aks/gitops/values/web-apps/theme.yaml
+++ b/applications/aks/gitops/values/web-apps/theme.yaml
@@ -3,7 +3,7 @@ env:
   FEATURE_FLAG_ENABLE_NOTIFICATION_BANNER_UN_9411: "true"
   SELF_URL: https://hello.azure.unique.dev/theme
 image:
-  tag: "2025.04"
+  tag: "2025.06"
   repository: uniquehelloazure.azurecr.io/web-app-theme
 nodeSelector:
   scalability: steady

--- a/applications/aks/release/app.unique.yaml
+++ b/applications/aks/release/app.unique.yaml
@@ -1,19 +1,19 @@
 sourceRegistry: uniquecr.azurecr.io
 targetRegistryName: uniquehelloazure
 images:
-- name: ai-service-assistants-core:2025.04
-- name: ai-service-assistants-reranker:2025.04
-- name: backend-service-app-repository:2025.04
-- name: backend-service-chat:2025.04
-- name: backend-service-event-socket:2025.04
-- name: backend-service-client-insights-exporter:2025.04
-- name: backend-service-ingestion-worker:2025.04
-- name: backend-service-ingestion:2025.04
-- name: backend-service-scope-management:2025.04
-- name: backend-service-theme:2025.04
-- name: backend-service-webhook-scheduler:2025.04
-- name: backend-service-webhook-worker:2025.04
-- name: web-app-admin:2025.04
-- name: web-app-chat:2025.04
-- name: web-app-knowledge-upload:2025.04
-- name: web-app-theme:2025.04
+- name: ai-service-assistants-core:2025.06
+- name: ai-service-assistants-reranker:2025.06
+- name: backend-service-app-repository:2025.06
+- name: backend-service-chat:2025.06
+- name: backend-service-event-socket:2025.06
+- name: backend-service-client-insights-exporter:2025.06
+- name: backend-service-ingestion-worker:2025.06
+- name: backend-service-ingestion:2025.06
+- name: backend-service-scope-management:2025.06
+- name: backend-service-theme:2025.06
+- name: backend-service-webhook-scheduler:2025.06
+- name: backend-service-webhook-worker:2025.06
+- name: web-app-admin:2025.06
+- name: web-app-chat:2025.06
+- name: web-app-knowledge-upload:2025.06
+- name: web-app-theme:2025.06

--- a/terraform-modules/workloads/openai.tf
+++ b/terraform-modules/workloads/openai.tf
@@ -1,5 +1,5 @@
 module "openai" {
-  source                      = "github.com/unique-ag/terraform-modules.git//modules/azure-openai?depth=1&ref=azure-openai-2.0.1"
+  source                      = "github.com/unique-ag/terraform-modules.git//modules/azure-openai?depth=1&ref=azure-openai-2.0.3"
   resource_group_name         = data.azurerm_resource_group.core.name
   tags                        = var.tags
   endpoint_secret_name_suffix = "-ep"
@@ -7,7 +7,7 @@ module "openai" {
     "cognitive-account-swedencentral" = {
       name                          = "cognitive-account-swedencentral"
       location                      = "swedencentral"
-      local_auth_enabled            = true
+      local_auth_enabled            = false
       custom_subdomain_name         = var.custom_subdomain_name
       public_network_access_enabled = true # FIXME: use private endpoints
       cognitive_deployments = [


### PR DESCRIPTION
- Update to release 2025.06
- Disable usage of local auth for OpenAI since we use workload identities