### PR TITLE
feat: Add environment-specific custom role names in identities module

### DIFF
--- a/infrastructure/test/environment.auto.tfvars
+++ b/infrastructure/test/environment.auto.tfvars
@@ -16,6 +16,10 @@ csi_identity_name                   = "csi-id-test"
 main_kv_name                        = "hakv1test"
 sensitive_kv_name                   = "hakv2test"
 environment                         = "test"
+container_registry_name             = "uqhacrtest"
+redis_name                          = "uqharedis-test"
+ingestion_cache_sa_name             = "uqhacache-test"
+ingestion_storage_sa_name           = "uqhastorage-test"
 
 # DNS subdomain records
 dns_subdomain_records = {

--- a/infrastructure/test/environment.auto.tfvars
+++ b/infrastructure/test/environment.auto.tfvars
@@ -18,8 +18,8 @@ sensitive_kv_name                   = "hakv2test"
 environment                         = "test"
 container_registry_name             = "uqhacrtest"
 redis_name                          = "uqharedis-test"
-ingestion_cache_sa_name             = "uqhacache-test"
-ingestion_storage_sa_name           = "uqhastorage-test"
+ingestion_cache_sa_name             = "uqhacachetest"
+ingestion_storage_sa_name           = "uqhastoragetest"
 
 # DNS subdomain records
 dns_subdomain_records = {

--- a/infrastructure/test/environment.auto.tfvars
+++ b/infrastructure/test/environment.auto.tfvars
@@ -15,6 +15,7 @@ psql_identity_name                  = "psql-id-test"
 csi_identity_name                   = "csi-id-test"
 main_kv_name                        = "hakv1test"
 sensitive_kv_name                   = "hakv2test"
+environment                         = "test"
 
 # DNS subdomain records
 dns_subdomain_records = {

--- a/infrastructure/test/main.tf
+++ b/infrastructure/test/main.tf
@@ -13,6 +13,7 @@ locals {
 module "identities" {
   source = "../../terraform-modules/identities"
 
+  environment                                  = var.environment
   aks_user_assigned_identity_name              = var.aks_identity_name
   application_gateway_id                       = module.workloads.application_gateway_id
   application_registration_gitops_display_name = var.gitops_display_name

--- a/infrastructure/test/main.tf
+++ b/infrastructure/test/main.tf
@@ -94,6 +94,10 @@ module "workloads" {
   subnet_aks_nodes_id                             = module.vnet.subnets["snet-aks-nodes"].resource_id
   tags                                            = var.tags
   tenant_id                                       = var.tenant_id
+  container_registry_name                         = var.container_registry_name
+  redis_name                                      = var.redis_name
+  ingestion_cache_sa_name                         = var.ingestion_cache_sa_name
+  ingestion_storage_sa_name                       = var.ingestion_storage_sa_name
 
   depends_on = [
     module.identities.resource_group_core_id,

--- a/infrastructure/test/variables.tf
+++ b/infrastructure/test/variables.tf
@@ -188,3 +188,23 @@ variable "environment" {
   description = "Environment name (e.g., dev, staging, prod)"
   type        = string
 }
+
+variable "container_registry_name" {
+  description = "Name of the Azure Container Registry"
+  type        = string
+}
+
+variable "redis_name" {
+  description = "Name of the Azure Redis Cache instance"
+  type        = string
+}
+
+variable "ingestion_cache_sa_name" {
+  description = "Name of the storage account used for ingestion cache"
+  type        = string
+}
+
+variable "ingestion_storage_sa_name" {
+  description = "Name of the storage account used for ingestion storage"
+  type        = string
+}

--- a/infrastructure/test/variables.tf
+++ b/infrastructure/test/variables.tf
@@ -183,3 +183,8 @@ variable "telemetry_observer_user_ids" {
   description = "List of user object IDs that will be granted permissions to view telemetry data"
   type        = list(string)
 }
+
+variable "environment" {
+  description = "Environment name (e.g., dev, staging, prod)"
+  type        = string
+}

--- a/terraform-modules/identities/custom-roles.tf
+++ b/terraform-modules/identities/custom-roles.tf
@@ -1,5 +1,9 @@
+locals {
+  env_suffix = var.environment != null ? "-${var.environment}" : ""
+}
+
 resource "azurerm_role_definition" "emergency_admin" {
-  name  = "Emergency Admin"
+  name  = "Emergency Admin${local.env_suffix}"
   scope = data.azurerm_subscription.current.id
 
   permissions {
@@ -15,7 +19,7 @@ resource "azurerm_role_definition" "emergency_admin" {
 }
 
 resource "azurerm_role_definition" "devops_preview" {
-  name  = "DevOps"
+  name  = "DevOps${local.env_suffix}"
   scope = data.azurerm_subscription.current.id
 
   permissions {
@@ -32,7 +36,7 @@ resource "azurerm_role_definition" "devops_preview" {
 }
 
 resource "azurerm_role_definition" "telemetry_observer" {
-  name  = "Telemetry Observer"
+  name  = "Telemetry Observer${local.env_suffix}"
   scope = data.azurerm_subscription.current.id
 
   permissions {
@@ -49,7 +53,7 @@ resource "azurerm_role_definition" "telemetry_observer" {
 }
 
 resource "azurerm_role_definition" "sensitive_data_observer" {
-  name  = "Sensitive Data Observer"
+  name  = "Sensitive Data Observer${local.env_suffix}"
   scope = data.azurerm_subscription.current.id
 
   permissions {
@@ -65,7 +69,7 @@ resource "azurerm_role_definition" "sensitive_data_observer" {
 }
 
 resource "azurerm_role_definition" "vnet_subnet_access" {
-  name  = "VNet Subnet Access (Preview)"
+  name  = "VNet Subnet Access (Preview)${local.env_suffix}"
   scope = data.azurerm_subscription.current.id
 
   permissions {
@@ -84,7 +88,7 @@ resource "azurerm_role_definition" "vnet_subnet_access" {
 }
 
 resource "azurerm_role_definition" "acr_puller" {
-  name  = "AcrPull Principals"
+  name  = "AcrPull Principals${local.env_suffix}"
   scope = data.azurerm_subscription.current.id
 
   permissions {

--- a/terraform-modules/identities/variables.tf
+++ b/terraform-modules/identities/variables.tf
@@ -195,3 +195,9 @@ variable "application_registration_gitops_display_name" {
   description = "Display name for the GitOps application registration"
   type        = string
 }
+
+variable "environment" {
+  description = "Environment name (e.g., dev, staging, prod)"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
- Added `environment` variable to identities module
- Updated custom role definitions to include optional environment suffix
- Introduced local variable `env_suffix` to conditionally append environment name
- Updated test environment configuration to pass environment variable