### PR TITLE
feat: Add new user ID to test environment access lists

### DIFF
--- a/infrastructure/test/environment.auto.tfvars
+++ b/infrastructure/test/environment.auto.tfvars
@@ -52,22 +52,26 @@ resource_vnet_location            = "swedencentral"
 cluster_admin_user_ids = [
   "4b89a1f0-8038-4929-81e6-6d128dac7aa0",
   "084a1c45-5010-4aab-bab6-7b86a9d10e5c",
-  "3b48f167-cb68-4655-b45b-878e170af84d"
+  "3b48f167-cb68-4655-b45b-878e170af84d",
+  "0a28a069-6af6-43a3-9ef4-4b2a9c6d1b86"
 ]
 gitops_maintainer_user_ids = [
   "4b89a1f0-8038-4929-81e6-6d128dac7aa0",
   "084a1c45-5010-4aab-bab6-7b86a9d10e5c",
-  "3b48f167-cb68-4655-b45b-878e170af84d"
+  "3b48f167-cb68-4655-b45b-878e170af84d",
+  "0a28a069-6af6-43a3-9ef4-4b2a9c6d1b86"
 ]
 keyvault_secret_writer_user_ids = [
   "4b89a1f0-8038-4929-81e6-6d128dac7aa0",
   "084a1c45-5010-4aab-bab6-7b86a9d10e5c",
-  "3b48f167-cb68-4655-b45b-878e170af84d"
+  "3b48f167-cb68-4655-b45b-878e170af84d",
+  "0a28a069-6af6-43a3-9ef4-4b2a9c6d1b86"
 ]
 telemetry_observer_user_ids = [
   "4b89a1f0-8038-4929-81e6-6d128dac7aa0",
   "084a1c45-5010-4aab-bab6-7b86a9d10e5c",
-  "3b48f167-cb68-4655-b45b-878e170af84d"
+  "3b48f167-cb68-4655-b45b-878e170af84d",
+  "0a28a069-6af6-43a3-9ef4-4b2a9c6d1b86"
 ]
 
 custom_subdomain_name = "ha-test" 


### PR DESCRIPTION
- Added a new user ID (0a28a069-6af6-43a3-9ef4-4b2a9c6d1b86) to cluster admin, gitops maintainer, key vault secret writer, and telemetry observer user lists
- Updated test environment access configuration