### PR TITLE
feat: add a network policy to limit access to Qdrant only from unique namespace

### DIFF
--- a/applications/aks/dev/gitops/qdrant.app.yaml
+++ b/applications/aks/dev/gitops/qdrant.app.yaml
@@ -1,34 +1,39 @@
 spec:
   name: qdrant
   autoSync: false
-  source:
-    chart: qdrant
-    repoURL: https://qdrant.github.io/qdrant-helm
-    targetRevision: 1.13.1
-    helm:
-      releaseName: qdrant
-      valuesObject:
-        replicaCount: 1
-        image:
-          repository: uniquehelloazure.azurecr.io/qdrant/qdrant
-          tag: v1.13.1
-          useUnprivilegedImage: true # auto-appends -unprivileged to the tag
-        updateVolumeFsOwnership: false # as this is a new cluster, the file system was never running as root
-        resources:
-          requests:
-            cpu: 100m
-            memory: 1.8Gi
-          limits:
-            memory: 2Gi
-        nodeSelector:
-          scalability: steady
-          lifecycle: persistent
-        persistence:
-          accessModes:
-            - ReadWriteOnce
-          size: 10Gi
-          storageClassName: default-zrs
-        startupProbe:
-          enabled: true
-          failureThreshold: 30
-          periodSeconds: 30
+  sources:
+    - chart: qdrant
+      repoURL: https://qdrant.github.io/qdrant-helm
+      targetRevision: 1.13.1
+      helm:
+        releaseName: qdrant
+        valuesObject:
+          replicaCount: 1
+          image:
+            repository: uniquehelloazure.azurecr.io/qdrant/qdrant
+            tag: v1.13.1
+            useUnprivilegedImage: true # auto-appends -unprivileged to the tag
+          updateVolumeFsOwnership: false # as this is a new cluster, the file system was never running as root
+          resources:
+            requests:
+              cpu: 100m
+              memory: 1.8Gi
+            limits:
+              memory: 2Gi
+          nodeSelector:
+            scalability: steady
+            lifecycle: persistent
+          persistence:
+            accessModes:
+              - ReadWriteOnce
+            size: 10Gi
+            storageClassName: default-zrs
+          startupProbe:
+            enabled: true
+            failureThreshold: 30
+            periodSeconds: 30
+    - repoURL: https://github.com/Unique-AG/hello-azure
+      targetRevision: preview
+      path: applications/aks/dev/gitops/values/qdrant
+      directory:
+        recurse: true

--- a/applications/aks/dev/gitops/values/qdrant/network-policy.yaml
+++ b/applications/aks/dev/gitops/values/qdrant/network-policy.yaml
@@ -1,0 +1,17 @@
+# Policy allowing incoming traffic to come only from the same namespace
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: qdrant-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: qdrant
+      app.kubernetes.io/instance: qdrant
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: unique
+  policyTypes:
+    - Ingress


### PR DESCRIPTION
Since Qdrant is running unprotected, let's set a network policy so it can be accessed only by pods in the same namespace. This is mostly an issue for shared clusters