### PR TITLE
feat(external-secrets): add audit storage ConfigMap support

### DIFF
--- a/applications/dev/apps/system/external-secrets.yaml
+++ b/applications/dev/apps/system/external-secrets.yaml
@@ -7,9 +7,16 @@ spec:
       ref: values
     - repoURL: https://charts.external-secrets.io
       chart: external-secrets
-      targetRevision: 0.16.1
+      targetRevision: 1.1.0
       helm:
         releaseName: external-secrets
+        values: |
+          extraArgs:
+            - --unsafe-allow-generic-targets
+          nonSecretTargets:
+            enabled: true
+            rbac:
+              configMaps: true
     - chart: raw
       repoURL: https://bedag.github.io/helm-charts
       targetRevision: 2.0.0

--- a/applications/dev/values/backend-services/_all.yaml
+++ b/applications/dev/values/backend-services/_all.yaml
@@ -12,3 +12,30 @@ resources: # TODO: @PROD-CHANGE: these are minimal resources. Remove this overri
   requests:
     cpu: 50m
     memory: 220Mi
+extraManifests:
+  - apiVersion: external-secrets.io/v1beta1
+    kind: ExternalSecret
+    metadata:
+      name: audit-volume-config
+      annotations:
+        external-secrets.io/managed: "true"
+        argocd.argoproj.io/sync-wave: "-1"
+        helm.sh/hook: pre-install,pre-upgrade
+        helm.sh/hook-weight: "-1"
+    spec:
+      refreshInterval: 1h
+      secretStoreRef:
+        kind: SecretStore
+        name: helloazuresensitive
+      target:
+        name: audit-volume-config
+        manifest:
+          apiVersion: v1
+          kind: ConfigMap
+      data:
+        - secretKey: resourceGroup
+          remoteRef:
+            key: audit-storage-resource-group
+        - secretKey: storageAccount
+          remoteRef:
+            key: audit-storage-account-name

--- a/applications/dev/values/backend-services/_all.yaml
+++ b/applications/dev/values/backend-services/_all.yaml
@@ -16,7 +16,7 @@ extraManifests:
   - apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
-      name: audit-volume-config
+      name: audit-volume-config-{{ .Release.Name }}
       annotations:
         external-secrets.io/managed: "true"
         argocd.argoproj.io/sync-wave: "-1"

--- a/applications/dev/values/backend-services/client-insights-exporter.yaml
+++ b/applications/dev/values/backend-services/client-insights-exporter.yaml
@@ -1,3 +1,4 @@
 image:
   tag: "2025.46"
   repository: uniquehelloazure.azurecr.io/backend-service-client-insights-exporter
+extraManifests: []

--- a/applications/dev/values/backend-services/event-socket.yaml
+++ b/applications/dev/values/backend-services/event-socket.yaml
@@ -1,6 +1,7 @@
 image:
   tag: "2025.46"
   repository: uniquehelloazure.azurecr.io/backend-service-event-socket
+extraManifests: []
 routes:
   gateway:
     namespace: unique

--- a/applications/dev/values/backend-services/speech.yaml
+++ b/applications/dev/values/backend-services/speech.yaml
@@ -1,6 +1,7 @@
 image:
   repository: uniquehelloazure.azurecr.io/backend-service-speech
   tag: "2025.46"
+extraManifests: []
 replicaCount: 2
 resources:
   limits:

--- a/applications/dev/values/backend-services/webhook-scheduler.yaml
+++ b/applications/dev/values/backend-services/webhook-scheduler.yaml
@@ -1,3 +1,4 @@
 image:
   tag: "2025.46"
   repository: uniquehelloazure.azurecr.io/backend-service-webhook-scheduler
+extraManifests: []

--- a/applications/dev/values/backend-services/webhook-worker.yaml
+++ b/applications/dev/values/backend-services/webhook-worker.yaml
@@ -1,3 +1,4 @@
 image:
   tag: "2025.46"
   repository: uniquehelloazure.azurecr.io/backend-service-webhook-worker
+extraManifests: []

--- a/applications/test/apps/system/external-secrets.yaml
+++ b/applications/test/apps/system/external-secrets.yaml
@@ -7,9 +7,16 @@ spec:
       ref: values
     - repoURL: https://charts.external-secrets.io
       chart: external-secrets
-      targetRevision: 0.16.1
+      targetRevision: 1.1.0
       helm:
         releaseName: external-secrets
+        values: |
+          extraArgs:
+            - --unsafe-allow-generic-targets
+          nonSecretTargets:
+            enabled: true
+            rbac:
+              configMaps: true
     - chart: raw
       repoURL: https://bedag.github.io/helm-charts
       targetRevision: 2.0.0

--- a/applications/test/values/backend-services/_all.yaml
+++ b/applications/test/values/backend-services/_all.yaml
@@ -12,3 +12,30 @@ resources: # TODO: @PROD-CHANGE: these are minimal resources. Remove this overri
   requests:
     cpu: 50m
     memory: 220Mi
+extraManifests:
+  - apiVersion: external-secrets.io/v1beta1
+    kind: ExternalSecret
+    metadata:
+      name: audit-volume-config
+      annotations:
+        external-secrets.io/managed: "true"
+        argocd.argoproj.io/sync-wave: "-1"
+        helm.sh/hook: pre-install,pre-upgrade
+        helm.sh/hook-weight: "-1"
+    spec:
+      refreshInterval: 1h
+      secretStoreRef:
+        kind: SecretStore
+        name: helloazuresensitive
+      target:
+        name: audit-volume-config
+        manifest:
+          apiVersion: v1
+          kind: ConfigMap
+      data:
+        - secretKey: resourceGroup
+          remoteRef:
+            key: audit-storage-resource-group
+        - secretKey: storageAccount
+          remoteRef:
+            key: audit-storage-account-name

--- a/applications/test/values/backend-services/_all.yaml
+++ b/applications/test/values/backend-services/_all.yaml
@@ -16,7 +16,7 @@ extraManifests:
   - apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
-      name: audit-volume-config
+      name: audit-volume-config-{{ .Release.Name }}
       annotations:
         external-secrets.io/managed: "true"
         argocd.argoproj.io/sync-wave: "-1"

--- a/applications/test/values/backend-services/client-insights-exporter.yaml
+++ b/applications/test/values/backend-services/client-insights-exporter.yaml
@@ -1,3 +1,4 @@
 image:
   tag: "2025.46"
   repository: uqhacrtest.azurecr.io/backend-service-client-insights-exporter
+extraManifests: []

--- a/applications/test/values/backend-services/event-socket.yaml
+++ b/applications/test/values/backend-services/event-socket.yaml
@@ -1,6 +1,7 @@
 image:
   tag: "2025.46"
   repository: uqhacrtest.azurecr.io/backend-service-event-socket
+extraManifests: []
 routes:
   gateway:
     namespace: unique

--- a/applications/test/values/backend-services/speech.yaml
+++ b/applications/test/values/backend-services/speech.yaml
@@ -1,6 +1,7 @@
 image:
   repository: uqhacrtest.azurecr.io/backend-service-speech
   tag: "2025.46"
+extraManifests: []
 replicaCount: 2
 resources:
   limits:

--- a/applications/test/values/backend-services/webhook-scheduler.yaml
+++ b/applications/test/values/backend-services/webhook-scheduler.yaml
@@ -1,3 +1,4 @@
 image:
   tag: "2025.46"
   repository: uqhacrtest.azurecr.io/backend-service-webhook-scheduler
+extraManifests: []

--- a/applications/test/values/backend-services/webhook-worker.yaml
+++ b/applications/test/values/backend-services/webhook-worker.yaml
@@ -1,3 +1,4 @@
 image:
   tag: "2025.46"
   repository: uqhacrtest.azurecr.io/backend-service-webhook-worker
+extraManifests: []

--- a/applications/test/values/external-secrets/secret-store.yaml
+++ b/applications/test/values/external-secrets/secret-store.yaml
@@ -10,7 +10,7 @@ resources:
         azurekv:
           authType: ManagedIdentity
           identityId: 4817ad12-ecb1-4009-bfe2-966200fcd84c
-          vaultUrl: https://hakv2test.vault.azure.net
+          vaultUrl: https://hakv2testv2.vault.azure.net
           
   - apiVersion: external-secrets.io/v1beta1
     kind: SecretStore
@@ -23,4 +23,4 @@ resources:
         azurekv:
           authType: ManagedIdentity
           identityId: 4817ad12-ecb1-4009-bfe2-966200fcd84c
-          vaultUrl: https://hakv1test.vault.azure.net
+          vaultUrl: https://hakv1testv2.vault.azure.net

--- a/terraform-modules/workloads/secrets.tf
+++ b/terraform-modules/workloads/secrets.tf
@@ -96,3 +96,17 @@ resource "azurerm_key_vault_secret" "zitadel_pat" {
     ignore_changes = [value, tags]
   }
 }
+
+resource "azurerm_key_vault_secret" "audit_storage_resource_group" {
+  name            = var.audit_storage_resource_group_secret_name
+  value           = data.azurerm_resource_group.sensitive.name
+  key_vault_id    = var.sensitive_kv_id
+  expiration_date = "2099-12-31T23:59:59Z"
+}
+
+resource "azurerm_key_vault_secret" "audit_storage_account_name" {
+  name            = var.audit_storage_account_name_secret_name
+  value           = var.audit_storage_sa_name
+  key_vault_id    = var.sensitive_kv_id
+  expiration_date = "2099-12-31T23:59:59Z"
+}

--- a/terraform-modules/workloads/variables.tf
+++ b/terraform-modules/workloads/variables.tf
@@ -103,6 +103,18 @@ variable "audit_storage_sa_name" {
   default = "helloazureaudit"
 }
 
+variable "audit_storage_resource_group_secret_name" {
+  type        = string
+  description = "The name of the secret containing the audit storage resource group name."
+  default     = "audit-storage-resource-group"
+}
+
+variable "audit_storage_account_name_secret_name" {
+  type        = string
+  description = "The name of the secret containing the audit storage account name."
+  default     = "audit-storage-account-name"
+}
+
 variable "audit_containers" {
   description = "List of storage container names for audit logs"
   type        = list(string)


### PR DESCRIPTION
Upgrade External Secrets Operator from v0.16.1 to v1.1.0 and enable non-secret targets to support ConfigMap creation. Add Terraform resources for audit storage Key Vault secrets (resource group and storage account name). Create ExternalSecret manifest in backend services to generate audit-volume-config ConfigMap from Key Vault secrets. Allow individual services to opt out via extraManifests override.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade External Secrets Operator to v1.1.0 with non-secret ConfigMap targets and wire audit storage details via Key Vault secrets and ExternalSecret manifests; add opt-out overrides per service and update test vault URLs.
> 
> - **External Secrets Operator (dev/test)**
>   - Upgrade chart `external-secrets` from `0.16.1` to `1.1.0`.
>   - Helm values: enable `nonSecretTargets` with ConfigMap RBAC and add `--unsafe-allow-generic-targets`.
> - **Backend services values (dev/test)**
>   - Add `extraManifests` with an `ExternalSecret` to create `ConfigMap` `audit-volume-config` from Key Vault secrets `audit-storage-resource-group` and `audit-storage-account-name`.
>   - Set `extraManifests: []` in specific services (`client-insights-exporter`, `event-socket`, `speech`, `webhook-scheduler`, `webhook-worker`) to allow opting out.
> - **Terraform**
>   - Add Key Vault secrets for audit storage metadata: `audit_storage_resource_group` and `audit_storage_account_name` with new variables for secret names.
> - **Test env secret stores**
>   - Update Key Vault `vaultUrl`s to `hakv2testv2` and `hakv1testv2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85119ba14be9b9ea166c37b5a89d4794399e3fdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->