### PR TITLE
chore(release): prepare release 2026.04

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,26 @@
+# Local settings
+settings.local.json
+CLAUDE.local.md
+
+# Local command overrides
+commands/*.local.md
+
+# Local rules
+rules/*.local.md
+
+# Local skills
+skills/*.local.md
+skills/*.local/
+skills/*/*.local.md
+
+# Local agents
+agents/*.local.md
+
+# Local hooks
+hooks/*.local.md
+hooks/*.local.sh
+hooks/*.local.js
+
+# Temporary files
+*.tmp
+*.log

--- a/.cursor/.gitignore
+++ b/.cursor/.gitignore
@@ -1,0 +1,9 @@
+# Local rules
+rules/*.local.md
+rules/*.local.mdc
+rules/**/*.local.md
+rules/**/*.local.mdc
+
+# Temporary files
+*.tmp
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ mkdocs
 *.tfstate
 *.tfstate.backup
 .vscode
+.gates/
+.specs/

--- a/applications/defaults/backend-services/app-repository.yaml
+++ b/applications/defaults/backend-services/app-repository.yaml
@@ -34,7 +34,7 @@ envVars:
 hooks:
   migration:
     command: |
-      cd /home/node/app/services/node-app-repository/prisma; npx prisma migrate deploy;
+      cd /home/node/app/services/node-app-repository/prisma; npx prisma migrate deploy --config ../prisma.config.ts;
     enabled: true
 nodeSelector:
   scalability: steady

--- a/applications/defaults/backend-services/chat.yaml
+++ b/applications/defaults/backend-services/chat.yaml
@@ -102,7 +102,7 @@ envVars:
 hooks:
   migration:
     command: |
-      cd /home/node/app/services/node-chat/prisma; npx prisma migrate deploy; cd /home/node/app/services/node-chat/dist; RUNNING_MODE=DATA_MIGRATION node /home/node/app/services/node-chat/dist/main.js;
+      cd /home/node/app/services/node-chat/prisma; npx prisma migrate deploy --config ../prisma.config.ts; cd /home/node/app/services/node-chat/dist; RUNNING_MODE=DATA_MIGRATION node /home/node/app/services/node-chat/dist/main.js;
     enabled: true
 nodeSelector:
   scalability: steady

--- a/applications/defaults/backend-services/configuration.yaml
+++ b/applications/defaults/backend-services/configuration.yaml
@@ -12,7 +12,7 @@ env:
 hooks:
   migration:
     command: |
-      cd /home/node/app/services/configuration-backend/prisma; npx prisma migrate deploy;
+      cd /home/node/app/services/configuration-backend/prisma; npx prisma migrate deploy --config ../prisma.config.ts;
     enabled: true
 replicaCount: 1
 resources:

--- a/applications/defaults/backend-services/ingestion.yaml
+++ b/applications/defaults/backend-services/ingestion.yaml
@@ -90,7 +90,7 @@ extraCronJobs:
 hooks:
   migration:
     command: |
-      cd /home/node/app/services/node-ingestion/prisma; npx prisma migrate deploy;
+      cd /home/node/app/services/node-ingestion/prisma; npx prisma migrate deploy --config ../prisma.config.ts;
     enabled: true
 nodeSelector:
   scalability: steady

--- a/applications/defaults/backend-services/scope-management.yaml
+++ b/applications/defaults/backend-services/scope-management.yaml
@@ -57,7 +57,7 @@ nodeSelector:
 hooks:
   migration:
     command: |
-      cd /home/node/app/services/node-scope-management/prisma; npx prisma migrate deploy; cd /home/node/app/services/node-scope-management/dist; RUNNING_MODE=DATA_MIGRATION  node /home/node/app/services/node-scope-management/dist/main.js;
+      cd /home/node/app/services/node-scope-management/prisma; npx prisma migrate deploy --config ../prisma.config.ts; cd /home/node/app/services/node-scope-management/dist; RUNNING_MODE=DATA_MIGRATION  node /home/node/app/services/node-scope-management/dist/main.js;
     enabled: true
 replicaCount: 1
 resources:

--- a/applications/dev/values/ai-services/assistants-core.yaml
+++ b/applications/dev/values/ai-services/assistants-core.yaml
@@ -3,7 +3,7 @@ env:
   ZITADEL_PROJECT_ID: "305512913743905383"
   UNIQUE_INSTALLATION_ID: hello.azure.unique.dev # the hostname of the cluster
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uniquehelloazure.azurecr.io/ai-service-assistants-core
 replicaCount: 2
 resources:

--- a/applications/dev/values/backend-services/app-repository.yaml
+++ b/applications/dev/values/backend-services/app-repository.yaml
@@ -3,7 +3,7 @@ auditVolume:
     resourceGroup: resource-group-sensitive
     storageAccount: helloazureauditf7b2fc2f
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uniquehelloazure.azurecr.io/backend-service-app-repository
 routes:
   hostname: api.hello.azure.unique.dev

--- a/applications/dev/values/backend-services/chat.yaml
+++ b/applications/dev/values/backend-services/chat.yaml
@@ -20,7 +20,7 @@ env:
   PUBSUB_REDIS_DB: 2
   SCOPE_MANAGEMENT_API_URL: http://backend-service-scope-management.unique.svc
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uniquehelloazure.azurecr.io/backend-service-chat
 resources:
   limits:

--- a/applications/dev/values/backend-services/client-insights-exporter.yaml
+++ b/applications/dev/values/backend-services/client-insights-exporter.yaml
@@ -1,3 +1,3 @@
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uniquehelloazure.azurecr.io/backend-service-client-insights-exporter

--- a/applications/dev/values/backend-services/configuration.yaml
+++ b/applications/dev/values/backend-services/configuration.yaml
@@ -4,7 +4,7 @@ auditVolume:
     storageAccount: helloazureauditf7b2fc2f
 image:
   repository: uniquehelloazure.azurecr.io/backend-service-configuration
-  tag: "2025.52.0"
+  tag: "2026.04.2"
 secretProvider:
   vaults:
     helloazuresensitive:

--- a/applications/dev/values/backend-services/event-socket.yaml
+++ b/applications/dev/values/backend-services/event-socket.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uniquehelloazure.azurecr.io/backend-service-event-socket
 routes:
   gateway:

--- a/applications/dev/values/backend-services/ingestion-worker.yaml
+++ b/applications/dev/values/backend-services/ingestion-worker.yaml
@@ -3,7 +3,7 @@ auditVolume:
     resourceGroup: resource-group-sensitive
     storageAccount: helloazureauditf7b2fc2f
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uniquehelloazure.azurecr.io/backend-service-ingestion-worker
 secretProvider:
   vaults:

--- a/applications/dev/values/backend-services/ingestion.yaml
+++ b/applications/dev/values/backend-services/ingestion.yaml
@@ -47,7 +47,7 @@ envVars:
         name: elasticsearch-ingestion-es-elastic-user
         key: elastic
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uniquehelloazure.azurecr.io/backend-service-ingestion
 replicaCount: 2
 resources:

--- a/applications/dev/values/backend-services/scope-management.yaml
+++ b/applications/dev/values/backend-services/scope-management.yaml
@@ -3,7 +3,7 @@ auditVolume:
     resourceGroup: resource-group-sensitive
     storageAccount: helloazureauditf7b2fc2f
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uniquehelloazure.azurecr.io/backend-service-scope-management
 env:
   ZITADEL_HOST: https://id.hello.azure.unique.dev

--- a/applications/dev/values/backend-services/speech.yaml
+++ b/applications/dev/values/backend-services/speech.yaml
@@ -1,6 +1,6 @@
 image:
   repository: uniquehelloazure.azurecr.io/backend-service-speech
-  tag: "2025.52.0"
+  tag: "2026.04.2"
 replicaCount: 2
 resources:
   limits:

--- a/applications/dev/values/backend-services/webhook-scheduler.yaml
+++ b/applications/dev/values/backend-services/webhook-scheduler.yaml
@@ -1,3 +1,3 @@
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uniquehelloazure.azurecr.io/backend-service-webhook-scheduler

--- a/applications/dev/values/backend-services/webhook-worker.yaml
+++ b/applications/dev/values/backend-services/webhook-worker.yaml
@@ -1,3 +1,3 @@
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uniquehelloazure.azurecr.io/backend-service-webhook-worker

--- a/applications/dev/values/web-apps/admin.yaml
+++ b/applications/dev/values/web-apps/admin.yaml
@@ -1,5 +1,5 @@
 env:
   SELF_URL: https://hello.azure.unique.dev/admin
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uniquehelloazure.azurecr.io/web-app-admin

--- a/applications/dev/values/web-apps/chat.yaml
+++ b/applications/dev/values/web-apps/chat.yaml
@@ -6,5 +6,5 @@ env:
   SELF_URL: https://hello.azure.unique.dev/chat
   SPEECH_BACKEND_API_URL: wss://api.hello.azure.unique.dev/speech/ws/v1/speech-to-text
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uniquehelloazure.azurecr.io/web-app-chat

--- a/applications/dev/values/web-apps/knowledge-upload.yaml
+++ b/applications/dev/values/web-apps/knowledge-upload.yaml
@@ -1,5 +1,5 @@
 env:
   SELF_URL: https://hello.azure.unique.dev/knowledge-upload
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uniquehelloazure.azurecr.io/web-app-knowledge-upload

--- a/applications/dev/values/web-apps/theme.yaml
+++ b/applications/dev/values/web-apps/theme.yaml
@@ -1,5 +1,5 @@
 env:
   SELF_URL: https://hello.azure.unique.dev/theme
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uniquehelloazure.azurecr.io/web-app-theme

--- a/applications/test/values/ai-services/assistants-core.yaml
+++ b/applications/test/values/ai-services/assistants-core.yaml
@@ -3,7 +3,7 @@ env:
   ZITADEL_PROJECT_ID: "311604321709982327"
   UNIQUE_INSTALLATION_ID: test-hello.azure.unique.dev # the hostname of the cluster
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uqhacrtest.azurecr.io/ai-service-assistants-core
 replicaCount: 2
 resources:

--- a/applications/test/values/backend-services/app-repository.yaml
+++ b/applications/test/values/backend-services/app-repository.yaml
@@ -3,7 +3,7 @@ auditVolume:
     resourceGroup: resource-group-sensitive
     storageAccount: helloazureaudit66d7a195
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uqhacrtest.azurecr.io/backend-service-app-repository
 routes:
   hostname: api.test-hello.azure.unique.dev

--- a/applications/test/values/backend-services/chat.yaml
+++ b/applications/test/values/backend-services/chat.yaml
@@ -20,7 +20,7 @@ env:
   PUBSUB_REDIS_DB: 2
   SCOPE_MANAGEMENT_API_URL: http://backend-service-scope-management.unique.svc
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uqhacrtest.azurecr.io/backend-service-chat
 resources:
   limits:

--- a/applications/test/values/backend-services/client-insights-exporter.yaml
+++ b/applications/test/values/backend-services/client-insights-exporter.yaml
@@ -1,3 +1,3 @@
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uqhacrtest.azurecr.io/backend-service-client-insights-exporter

--- a/applications/test/values/backend-services/configuration.yaml
+++ b/applications/test/values/backend-services/configuration.yaml
@@ -4,7 +4,7 @@ auditVolume:
     storageAccount: helloazureaudit66d7a195
 image:
   repository: uqhacrtest.azurecr.io/backend-service-configuration
-  tag: "2025.52.0"
+  tag: "2026.04.2"
 secretProvider:
   vaults:
     hakv2test:

--- a/applications/test/values/backend-services/event-socket.yaml
+++ b/applications/test/values/backend-services/event-socket.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uqhacrtest.azurecr.io/backend-service-event-socket
 routes:
   gateway:

--- a/applications/test/values/backend-services/ingestion-worker.yaml
+++ b/applications/test/values/backend-services/ingestion-worker.yaml
@@ -3,7 +3,7 @@ auditVolume:
     resourceGroup: resource-group-sensitive
     storageAccount: helloazureaudit66d7a195
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uqhacrtest.azurecr.io/backend-service-ingestion-worker
 secretProvider:
   vaults:

--- a/applications/test/values/backend-services/ingestion.yaml
+++ b/applications/test/values/backend-services/ingestion.yaml
@@ -47,7 +47,7 @@ envVars:
         name: elasticsearch-ingestion-es-elastic-user
         key: elastic
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uqhacrtest.azurecr.io/backend-service-ingestion
 replicaCount: 2
 resources:

--- a/applications/test/values/backend-services/scope-management.yaml
+++ b/applications/test/values/backend-services/scope-management.yaml
@@ -3,7 +3,7 @@ auditVolume:
     resourceGroup: resource-group-sensitive
     storageAccount: helloazureaudit66d7a195
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uqhacrtest.azurecr.io/backend-service-scope-management
 env:
   ZITADEL_HOST: https://id.test-hello.azure.unique.dev

--- a/applications/test/values/backend-services/speech.yaml
+++ b/applications/test/values/backend-services/speech.yaml
@@ -1,6 +1,6 @@
 image:
   repository: uqhacrtest.azurecr.io/backend-service-speech
-  tag: "2025.52.0"
+  tag: "2026.04.2"
 replicaCount: 2
 resources:
   limits:

--- a/applications/test/values/backend-services/webhook-scheduler.yaml
+++ b/applications/test/values/backend-services/webhook-scheduler.yaml
@@ -1,3 +1,3 @@
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uqhacrtest.azurecr.io/backend-service-webhook-scheduler

--- a/applications/test/values/backend-services/webhook-worker.yaml
+++ b/applications/test/values/backend-services/webhook-worker.yaml
@@ -1,3 +1,3 @@
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uqhacrtest.azurecr.io/backend-service-webhook-worker

--- a/applications/test/values/web-apps/admin.yaml
+++ b/applications/test/values/web-apps/admin.yaml
@@ -1,5 +1,5 @@
 env:
   SELF_URL: https://test-hello.azure.unique.dev/admin
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uqhacrtest.azurecr.io/web-app-admin

--- a/applications/test/values/web-apps/chat.yaml
+++ b/applications/test/values/web-apps/chat.yaml
@@ -6,5 +6,5 @@ env:
   SELF_URL: https://test-hello.azure.unique.dev/chat
   SPEECH_BACKEND_API_URL: wss://api.test-hello.azure.unique.dev/speech/ws/v1/speech-to-text
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uqhacrtest.azurecr.io/web-app-chat

--- a/applications/test/values/web-apps/knowledge-upload.yaml
+++ b/applications/test/values/web-apps/knowledge-upload.yaml
@@ -1,5 +1,5 @@
 env:
   SELF_URL: https://test-hello.azure.unique.dev/knowledge-upload
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uqhacrtest.azurecr.io/web-app-knowledge-upload

--- a/applications/test/values/web-apps/theme.yaml
+++ b/applications/test/values/web-apps/theme.yaml
@@ -1,5 +1,5 @@
 env:
   SELF_URL: https://test-hello.azure.unique.dev/theme
 image:
-  tag: "2025.52.0"
+  tag: "2026.04.2"
   repository: uqhacrtest.azurecr.io/web-app-theme

--- a/mirroring/dev/app.unique.yaml
+++ b/mirroring/dev/app.unique.yaml
@@ -1,19 +1,19 @@
 sourceRegistry: uniquecr.azurecr.io
 targetRegistryName: uniquehelloazure
 images:
-  - name: ai-service-assistants-core:2025.52.0
-  - name: backend-service-app-repository:2025.52.0
-  - name: backend-service-chat:2025.52.0
-  - name: backend-service-event-socket:2025.52.0
-  - name: backend-service-client-insights-exporter:2025.52.0
-  - name: backend-service-ingestion-worker:2025.52.0
-  - name: backend-service-ingestion:2025.52.0
-  - name: backend-service-scope-management:2025.52.0
-  - name: backend-service-webhook-scheduler:2025.52.0
-  - name: backend-service-webhook-worker:2025.52.0
-  - name: backend-service-configuration:2025.52.0
-  - name: web-app-admin:2025.52.0
-  - name: web-app-chat:2025.52.0
-  - name: web-app-knowledge-upload:2025.52.0
-  - name: web-app-theme:2025.52.0
-  - name: backend-service-speech:2025.52.0
+  - name: ai-service-assistants-core:2026.04.2
+  - name: backend-service-app-repository:2026.04.2
+  - name: backend-service-chat:2026.04.2
+  - name: backend-service-event-socket:2026.04.2
+  - name: backend-service-client-insights-exporter:2026.04.2
+  - name: backend-service-ingestion-worker:2026.04.2
+  - name: backend-service-ingestion:2026.04.2
+  - name: backend-service-scope-management:2026.04.2
+  - name: backend-service-webhook-scheduler:2026.04.2
+  - name: backend-service-webhook-worker:2026.04.2
+  - name: backend-service-configuration:2026.04.2
+  - name: web-app-admin:2026.04.2
+  - name: web-app-chat:2026.04.2
+  - name: web-app-knowledge-upload:2026.04.2
+  - name: web-app-theme:2026.04.2
+  - name: backend-service-speech:2026.04.2

--- a/mirroring/test/app.unique.yaml
+++ b/mirroring/test/app.unique.yaml
@@ -1,19 +1,19 @@
 sourceRegistry: uniquecr.azurecr.io
 targetRegistryName: uqhacrtest
 images:
-  - name: ai-service-assistants-core:2025.52.0
-  - name: backend-service-app-repository:2025.52.0
-  - name: backend-service-chat:2025.52.0
-  - name: backend-service-event-socket:2025.52.0
-  - name: backend-service-client-insights-exporter:2025.52.0
-  - name: backend-service-ingestion-worker:2025.52.0
-  - name: backend-service-ingestion:2025.52.0
-  - name: backend-service-scope-management:2025.52.0
-  - name: backend-service-webhook-scheduler:2025.52.0
-  - name: backend-service-webhook-worker:2025.52.0
-  - name: backend-service-configuration:2025.52.0
-  - name: web-app-admin:2025.52.0
-  - name: web-app-chat:2025.52.0
-  - name: web-app-knowledge-upload:2025.52.0
-  - name: web-app-theme:2025.52.0
-  - name: backend-service-speech:2025.52.0
+  - name: ai-service-assistants-core:2026.04.2
+  - name: backend-service-app-repository:2026.04.2
+  - name: backend-service-chat:2026.04.2
+  - name: backend-service-event-socket:2026.04.2
+  - name: backend-service-client-insights-exporter:2026.04.2
+  - name: backend-service-ingestion-worker:2026.04.2
+  - name: backend-service-ingestion:2026.04.2
+  - name: backend-service-scope-management:2026.04.2
+  - name: backend-service-webhook-scheduler:2026.04.2
+  - name: backend-service-webhook-worker:2026.04.2
+  - name: backend-service-configuration:2026.04.2
+  - name: web-app-admin:2026.04.2
+  - name: web-app-chat:2026.04.2
+  - name: web-app-knowledge-upload:2026.04.2
+  - name: web-app-theme:2026.04.2
+  - name: backend-service-speech:2026.04.2


### PR DESCRIPTION
## Changes

- Bump image tags to `2026.04.2` for all services (dev + test)
- Add `--config ../prisma.config.ts` to Prisma migration commands
- Update mirroring versions to `2026.04.2`
- Add local agent files to .gitignore