### PR TITLE
feat(monitoring): add blackbox exporter and AMA probe jobs for dev/test

### DIFF
--- a/applications/dev/apps/system/blackbox-exporter.yaml
+++ b/applications/dev/apps/system/blackbox-exporter.yaml
@@ -1,0 +1,14 @@
+spec:
+  name: blackbox-exporter
+  autoSync: false
+  sources:
+    - repoURL: 'https://github.com/Unique-AG/hello-azure'
+      targetRevision: preview
+      ref: values
+    - chart: prometheus-blackbox-exporter
+      repoURL: https://prometheus-community.github.io/helm-charts
+      targetRevision: 11.7.1
+      helm:
+        releaseName: blackbox-exporter
+        valueFiles:
+          - $values/applications/dev/values/blackbox-exporter/blackbox-exporter.yaml

--- a/applications/dev/values/aks-extensions/ama-metrics-prometheus-config.yaml
+++ b/applications/dev/values/aks-extensions/ama-metrics-prometheus-config.yaml
@@ -55,3 +55,24 @@ resources:
             - source_labels: [__meta_kubernetes_pod_node_name]
               action: replace
               target_label: node
+        - job_name: blackbox-http
+          metrics_path: /probe
+          params:
+            module:
+              - http_any
+          scrape_interval: 60s
+          scrape_timeout: 15s
+          static_configs:
+            - targets:
+                - https://hello.azure.unique.dev
+                - https://api.hello.azure.unique.dev
+                - https://id.hello.azure.unique.dev
+                - https://acme-v02.api.letsencrypt.org/directory
+                - https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration
+          relabel_configs:
+            - source_labels: [__address__]
+              target_label: __param_target
+            - source_labels: [__param_target]
+              target_label: instance
+            - target_label: __address__
+              replacement: blackbox-exporter.unique.svc.cluster.local:9115

--- a/applications/dev/values/blackbox-exporter/blackbox-exporter.yaml
+++ b/applications/dev/values/blackbox-exporter/blackbox-exporter.yaml
@@ -1,0 +1,37 @@
+fullnameOverride: blackbox-exporter
+image:
+  repository: uniquehelloazure.azurecr.io/prometheus/blackbox-exporter
+  tag: v0.28.0
+config:
+  modules:
+    http_any:
+      prober: http
+      timeout: 10s
+      http:
+        valid_status_codes:
+          - 200
+          - 201
+          - 301
+          - 302
+          - 400
+          - 401
+          - 403
+          - 404
+          - 405
+        follow_redirects: false
+        preferred_ip_protocol: ip4
+        tls_config:
+          insecure_skip_verify: true
+    tcp_connect:
+      prober: tcp
+      timeout: 10s
+      tcp:
+        preferred_ip_protocol: ip4
+serviceMonitor:
+  enabled: false
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+  limits:
+    memory: 64Mi

--- a/applications/test/apps/system/blackbox-exporter.yaml
+++ b/applications/test/apps/system/blackbox-exporter.yaml
@@ -1,0 +1,14 @@
+spec:
+  name: blackbox-exporter
+  autoSync: false
+  sources:
+    - repoURL: 'https://github.com/Unique-AG/hello-azure'
+      targetRevision: preview
+      ref: values
+    - chart: prometheus-blackbox-exporter
+      repoURL: https://prometheus-community.github.io/helm-charts
+      targetRevision: 11.7.1
+      helm:
+        releaseName: blackbox-exporter
+        valueFiles:
+          - $values/applications/test/values/blackbox-exporter/blackbox-exporter.yaml

--- a/applications/test/values/aks-extensions/ama-metrics-prometheus-config.yaml
+++ b/applications/test/values/aks-extensions/ama-metrics-prometheus-config.yaml
@@ -55,3 +55,24 @@ resources:
             - source_labels: [__meta_kubernetes_pod_node_name]
               action: replace
               target_label: node
+        - job_name: blackbox-http
+          metrics_path: /probe
+          params:
+            module:
+              - http_any
+          scrape_interval: 60s
+          scrape_timeout: 15s
+          static_configs:
+            - targets:
+                - https://test-hello.azure.unique.dev
+                - https://api.test-hello.azure.unique.dev
+                - https://id.test-hello.azure.unique.dev
+                - https://acme-v02.api.letsencrypt.org/directory
+                - https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration
+          relabel_configs:
+            - source_labels: [__address__]
+              target_label: __param_target
+            - source_labels: [__param_target]
+              target_label: instance
+            - target_label: __address__
+              replacement: blackbox-exporter.unique.svc.cluster.local:9115

--- a/applications/test/values/blackbox-exporter/blackbox-exporter.yaml
+++ b/applications/test/values/blackbox-exporter/blackbox-exporter.yaml
@@ -1,0 +1,37 @@
+fullnameOverride: blackbox-exporter
+image:
+  repository: uqhacrtest.azurecr.io/prometheus/blackbox-exporter
+  tag: v0.28.0
+config:
+  modules:
+    http_any:
+      prober: http
+      timeout: 10s
+      http:
+        valid_status_codes:
+          - 200
+          - 201
+          - 301
+          - 302
+          - 400
+          - 401
+          - 403
+          - 404
+          - 405
+        follow_redirects: false
+        preferred_ip_protocol: ip4
+        tls_config:
+          insecure_skip_verify: true
+    tcp_connect:
+      prober: tcp
+      timeout: 10s
+      tcp:
+        preferred_ip_protocol: ip4
+serviceMonitor:
+  enabled: false
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+  limits:
+    memory: 64Mi

--- a/mirroring/dev/io.quay.yaml
+++ b/mirroring/dev/io.quay.yaml
@@ -2,5 +2,6 @@ images:
   - name: jetstack/cert-manager-cainjector:v1.12.2
   - name: jetstack/cert-manager-webhook:v1.12.2
   - name: jetstack/cert-manager-controller:v1.12.2
+  - name: prometheus/blackbox-exporter:v0.28.0
 sourceRegistry: quay.io
 targetRegistry: uniquehelloazure.azurecr.io

--- a/mirroring/test/io.quay.yaml
+++ b/mirroring/test/io.quay.yaml
@@ -2,5 +2,6 @@ images:
   - name: jetstack/cert-manager-cainjector:v1.12.2
   - name: jetstack/cert-manager-webhook:v1.12.2
   - name: jetstack/cert-manager-controller:v1.12.2
+  - name: prometheus/blackbox-exporter:v0.28.0
 sourceRegistry: quay.io
 targetRegistry: uqhacrtest.azurecr.io


### PR DESCRIPTION

Adds Blackbox Exporter to both `dev` and `test` Argo system apps, with environment-specific Helm values and ACR image overrides.

Also extends `ama-metrics-prometheus-config` in both environments with a new `blackbox-http` scrape job for key public endpoints, and updates mirroring configs to include `prometheus/blackbox-exporter:v0.28.0`.