### PR TITLE
fix(blackbox-exporter): update image configuration for dev and test e…

### DIFF
--- a/applications/dev/values/blackbox-exporter/blackbox-exporter.yaml
+++ b/applications/dev/values/blackbox-exporter/blackbox-exporter.yaml
@@ -1,6 +1,7 @@
 fullnameOverride: blackbox-exporter
 image:
-  repository: uniquehelloazure.azurecr.io/prometheus/blackbox-exporter
+  registry: uniquehelloazure.azurecr.io
+  repository: prometheus/blackbox-exporter
   tag: v0.28.0
 config:
   modules:

--- a/applications/test/values/blackbox-exporter/blackbox-exporter.yaml
+++ b/applications/test/values/blackbox-exporter/blackbox-exporter.yaml
@@ -1,6 +1,7 @@
 fullnameOverride: blackbox-exporter
 image:
-  repository: uqhacrtest.azurecr.io/prometheus/blackbox-exporter
+  registry: uqhacrtest.azurecr.io
+  repository: prometheus/blackbox-exporter
   tag: v0.28.0
 config:
   modules:


### PR DESCRIPTION
…nvironments

Refactor the image configuration in `blackbox-exporter.yaml` for both dev and test environments to separate the registry and repository fields. This change standardizes the image path to `prometheus/blackbox-exporter` while maintaining the existing tag `v0.28.0`.