### PR TITLE
ci(tool/github): add pinned actions verification workflow

### DIFF
--- a/.github/workflows/github.policies.verify.pinned-actions.yaml
+++ b/.github/workflows/github.policies.verify.pinned-actions.yaml
@@ -1,0 +1,28 @@
+name: "GitHub · Policies · Verify · Pinned Actions"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/**
+      - .github/actions/**
+
+jobs:
+  check-pinned-actions:
+    name: Verify action SHAs are pinned
+    runs-on: pulsar-spark
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Verify pinned actions
+        uses: unique-ag/actions/github/policies/verify-pinned-actions@84a4f60c0a56daae108b22e096b72bb10f476d08 # main

--- a/.github/workflows/github.policies.verify.pinned-actions.yaml
+++ b/.github/workflows/github.policies.verify.pinned-actions.yaml
@@ -18,7 +18,7 @@ on:
 jobs:
   check-pinned-actions:
     name: Verify action SHAs are pinned
-    runs-on: pulsar-spark
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- Adds the `github.policies.verify.pinned-actions.yaml` workflow to enforce SHA-pinned GitHub Actions
- Runs on PRs to `main` that modify `.github/workflows/**` or `.github/actions/**`
- Uses `unique-ag/actions/github/policies/verify-pinned-actions` to verify all actions are pinned to commit SHAs

## Test plan

- [ ] Verify workflow file is valid YAML
- [ ] Open a test PR modifying a workflow to confirm the check runs