### PR TITLE
chore(infra): add user to dev environment permissions

### DIFF
--- a/infrastructure/dev/environment.auto.tfvars
+++ b/infrastructure/dev/environment.auto.tfvars
@@ -52,7 +52,8 @@ cluster_admin_user_ids = [
   "084a1c45-5010-4aab-bab6-7b86a9d10e5c",
   "3b48f167-cb68-4655-b45b-878e170af84d",
   "45caeab6-e1dd-4f9a-aa0c-ea1fb6c0c5ff",
-  "0f309293-9600-4c19-bd7c-3dff1fa678d9"
+  "0f309293-9600-4c19-bd7c-3dff1fa678d9",
+  "fc34fb9d-14d1-41a2-bc67-ee8610b31e44"
 ]
 gitops_maintainer_user_ids = [
   "4ee4611f-b24c-444b-8d34-edab333bf868",
@@ -60,6 +61,7 @@ gitops_maintainer_user_ids = [
   "084a1c45-5010-4aab-bab6-7b86a9d10e5c",
   "3b48f167-cb68-4655-b45b-878e170af84d",
   "45caeab6-e1dd-4f9a-aa0c-ea1fb6c0c5ff",
+  "fc34fb9d-14d1-41a2-bc67-ee8610b31e44",
 ]
 keyvault_secret_writer_user_ids = [
   "4ee4611f-b24c-444b-8d34-edab333bf868",
@@ -67,7 +69,8 @@ keyvault_secret_writer_user_ids = [
   "084a1c45-5010-4aab-bab6-7b86a9d10e5c",
   "3b48f167-cb68-4655-b45b-878e170af84d",
   "45caeab6-e1dd-4f9a-aa0c-ea1fb6c0c5ff",
-  "0f309293-9600-4c19-bd7c-3dff1fa678d9"
+  "0f309293-9600-4c19-bd7c-3dff1fa678d9",
+  "fc34fb9d-14d1-41a2-bc67-ee8610b31e44"
 ]
 telemetry_observer_user_ids = [
   "4ee4611f-b24c-444b-8d34-edab333bf868",
@@ -75,7 +78,8 @@ telemetry_observer_user_ids = [
   "084a1c45-5010-4aab-bab6-7b86a9d10e5c",
   "3b48f167-cb68-4655-b45b-878e170af84d",
   "45caeab6-e1dd-4f9a-aa0c-ea1fb6c0c5ff",
-  "0f309293-9600-4c19-bd7c-3dff1fa678d9"
+  "0f309293-9600-4c19-bd7c-3dff1fa678d9",
+  "fc34fb9d-14d1-41a2-bc67-ee8610b31e44"
 ]
 
 custom_subdomain_name                       = "hello-azure"


### PR DESCRIPTION
## Summary
- Add user principal gustav.mango@unique.ai `fc34fb9d-14d1-41a2-bc67-ee8610b31e44` to all dev environment role assignments:
  - `cluster_admin_user_ids`
  - `gitops_maintainer_user_ids`
  - `keyvault_secret_writer_user_ids`
  - `telemetry_observer_user_ids`